### PR TITLE
Prevent uncontrollable generation with @\Model

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/DataWrapper-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/DataWrapper-Package.xcscheme
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DataWrapper"
+               BuildableName = "DataWrapper"
+               BlueprintName = "DataWrapper"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DataWrapperExamples"
+               BuildableName = "DataWrapperExamples"
+               BlueprintName = "DataWrapperExamples"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DataWrapperPluginTests"
+               BuildableName = "DataWrapperPluginTests"
+               BlueprintName = "DataWrapperPluginTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DataWrapperPluginTests"
+               BuildableName = "DataWrapperPluginTests"
+               BlueprintName = "DataWrapperPluginTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DataWrapperExamples"
+            BuildableName = "DataWrapperExamples"
+            BlueprintName = "DataWrapperExamples"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DataWrapperExamples"
+            BuildableName = "DataWrapperExamples"
+            BlueprintName = "DataWrapperExamples"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/DataWrapper.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/DataWrapper.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DataWrapper"
+               BuildableName = "DataWrapper"
+               BlueprintName = "DataWrapper"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DataWrapper"
+            BuildableName = "DataWrapper"
+            BlueprintName = "DataWrapper"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/DataWrapperExamples.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/DataWrapperExamples.xcscheme
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DataWrapperExamples"
+               BuildableName = "DataWrapperExamples"
+               BlueprintName = "DataWrapperExamples"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DataWrapperPluginTests"
+               BuildableName = "DataWrapperPluginTests"
+               BlueprintName = "DataWrapperPluginTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DataWrapperPluginTests"
+               BuildableName = "DataWrapperPluginTests"
+               BlueprintName = "DataWrapperPluginTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DataWrapperExamples"
+            BuildableName = "DataWrapperExamples"
+            BlueprintName = "DataWrapperExamples"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DataWrapperExamples"
+            BuildableName = "DataWrapperExamples"
+            BlueprintName = "DataWrapperExamples"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ import PackageDescription
 let package = Package(
     name: "DataWrapper",
     platforms: [
-        .iOS(.v16),
+        .iOS(.v17),
         .macOS(.v13),
     ],
     products: [

--- a/Sources/DataWrapper/DataWrapper.swift
+++ b/Sources/DataWrapper/DataWrapper.swift
@@ -1,5 +1,5 @@
 // The Swift Programming Language
 // https://docs.swift.org/swift-book
 
-@attached(member, names: arbitrary)
+@attached(member) @attached(peer)
 public macro DataModel() = #externalMacro(module: "DataWrapperPlugin", type: "DataModelMacro")

--- a/Sources/DataWrapper/DataWrapper.swift
+++ b/Sources/DataWrapper/DataWrapper.swift
@@ -1,5 +1,5 @@
 // The Swift Programming Language
 // https://docs.swift.org/swift-book
 
-@attached(member) @attached(peer)
+@attached(peer, names: suffixed(Data))
 public macro DataModel() = #externalMacro(module: "DataWrapperPlugin", type: "DataModelMacro")

--- a/Sources/DataWrapperExamples/main.swift
+++ b/Sources/DataWrapperExamples/main.swift
@@ -4,14 +4,13 @@ import CoreData
 import DataWrapper
 
 @DataModel
-class Schedule  {
-  struct Entity: Codable {
-    let id: String
-    let name: String
-  }
+struct Schedule  {
+  let id: String
+  let name: String
 }
 
-let schedule = Schedule(entity: .init(id: "", name: ""))
-let entity = Schedule.Entity(id: "", name: "")
+
+let schedule = ScheduleData.init(entity: .init(id: "", name: ""))
+let entity = ScheduleData.Entity(id: "", name: "")
 
 schedule.name

--- a/Sources/DataWrapperExamples/main.swift
+++ b/Sources/DataWrapperExamples/main.swift
@@ -4,7 +4,7 @@ import CoreData
 import DataWrapper
 
 @DataModel
-@dynamicMemberLookup class Schedule  {
+class Schedule  {
   struct Entity: Codable {
     let id: String
     let name: String

--- a/Sources/DataWrapperPlugin/DataModelMacro.swift
+++ b/Sources/DataWrapperPlugin/DataModelMacro.swift
@@ -2,7 +2,21 @@ import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxBuilder
 
-public struct DataModelMacro: MemberMacro {
+public struct DataModelMacro: MemberMacro, PeerMacro {
+  public static func expansion(of node: SwiftSyntax.AttributeSyntax, providingPeersOf declaration: some SwiftSyntax.DeclSyntaxProtocol, in context: some SwiftSyntaxMacros.MacroExpansionContext) throws -> [SwiftSyntax.DeclSyntax] {
+    switch declaration.kind {
+    case .classDecl:
+      let modelMacro = AttributeListSyntax {
+        "@Model"
+        "@dynamicMemberLookup"
+      }
+
+      return ["\(raw: modelMacro)"]
+    case _:
+      throw CustomError.message("@DataModel can only be applied to a struct or class declarations.")
+    }
+  }
+
   public static func expansion<Declaration, Context>(
     of node: AttributeSyntax,
     providingMembersOf declaration: Declaration,
@@ -23,7 +37,7 @@ public struct DataModelMacro: MemberMacro {
       }
 
       let member = MemberBlockItemListSyntax {
-"""
+      """
       var json: String
 
       init(entity: Entity) {

--- a/Sources/DataWrapperPlugin/DataModelMacro.swift
+++ b/Sources/DataWrapperPlugin/DataModelMacro.swift
@@ -23,7 +23,7 @@ public struct DataModelMacro: PeerMacro {
 
       let dataDecl = ClassDeclSyntax(
         attributes: .init(itemsBuilder: {
-//          "@Model"
+          "@Model"
           "@dynamicMemberLookup"
         }),
         classKeyword: " class ",

--- a/Sources/DataWrapperPlugin/DataWrapperPlugin.swift
+++ b/Sources/DataWrapperPlugin/DataWrapperPlugin.swift
@@ -4,8 +4,8 @@ import SwiftSyntaxMacros
 
 @main
 struct DataWrapperPlugin: CompilerPlugin {
-    let providingMacros: [Macro.Type] = [
-        DataModelMacro.self,
-    ]
+  let providingMacros: [Macro.Type] = [
+    DataModelMacro.self,
+  ]
 }
 #endif


### PR DESCRIPTION
## Abstract
`@Model` がついている前提のコード生成が安定しない。`@Model` に必要なinitの要件を満たしていないと怒られるので `@Model` 含めて class を生成する